### PR TITLE
added <body> tag onto layout.tsx

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,12 +13,14 @@ export default function RootLayout({
 }) {
   return (   
     <html lang="en">
-      <div className="fixed top-0 ">
-        <NavBar />
-      </div>
-      <div className='mt-20'>
-        <main>{children}</main>
-      </div>
+      <body>
+        <div className="fixed top-0 ">
+          <NavBar />
+        </div>
+        <div className='mt-20'>
+          <main>{children}</main>
+        </div>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
Apparently next.js requires us to also have a <body> tag on layout.tsx. This change got rid of the errors found on dev tools.